### PR TITLE
Added Hyphen Escaping

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,5 +5,5 @@ module.exports = function xkcd37 (str) {
     throw new TypeError('Expected a string')
   }
 
-  return str.replace(/(\S+?)-ass(\s+)(\S+?)/g, '$1$2ass-$3')
+  return str.replace(/(\w+?)(?!\\)+(-ass)(\s+)(\S+?)/g, '$1$3ass-$4').replace(/\\-/g, '-')
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 { "name": "xkcd-37"
-, "version": "1.0.0"
+, "version": "1.1.0"
 , "description": "Whenever anyone calls something an [adjective]-ass [noun], move the hyphen one word to the right."
 , "license": "MIT"
 , "repository": "goto-bus-stop/xkcd-37"
 , "author": "René Kooi <rene@kooi.me>"
 , "scripts":
-  { "test": "standard index.js && node ./test.js" }
+  { "test": "standard && node ./test.js" }
 , "files": [ "index.js" ]
 , "keywords":
   [ "xkcd"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 , "repository": "goto-bus-stop/xkcd-37"
 , "author": "René Kooi <rene@kooi.me>"
 , "scripts":
-  { "test": "standard && node ./test.js" }
+  { "test": "standard index.js && node ./test.js" }
 , "files": [ "index.js" ]
 , "keywords":
   [ "xkcd"

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,14 @@ var xkcd37 = require('xkcd-37')
 xkcd37('Man, that\'s a sweet-ass car')
 //=> 'Man, that\'s a sweet ass-car'
 ```
+### Advanced Usage
+Use a double backslash to not parse that part of the string.
+```js
+var xkcd37 = require('xkcd-37')
+
+xkcd37('Man, that\'s a sweet\\-ass car')
+//=> 'Man, that\'s a sweet-ass car'
+```
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -6,7 +6,7 @@ t.equal(xkcd37('Man, that\'s a sweet-ass car'), 'Man, that\'s a sweet ass-car')
 // Double Backslash should skip over it
 t.equal(xkcd37('Man, that\'s a sweet\\-ass car'), 'Man, that\'s a sweet-ass car')
 // Single Backslash won't escape and should return as if it were normal
-t.equal(xkcd37('Man, that\'s a sweet\-ass car'), 'Man, that\'s a sweet ass-car')
+t.equal(xkcd37('Man, that\'s a sweet\-ass car'), 'Man, that\'s a sweet ass-car') // eslint-disable-line no-useless-escape
 // Combined use
 t.equal(xkcd37('Man, that\'s a sweet-ass car, but I think you\'re just a rich\\-ass fuck.'), 'Man, that\'s a sweet ass-car, but I think you\'re just a rich-ass fuck.')
 

--- a/test.js
+++ b/test.js
@@ -1,7 +1,14 @@
 var xkcd37 = require('./')
 var t = require('assert')
 
+// Should move the hyphen over 1 word
 t.equal(xkcd37('Man, that\'s a sweet-ass car'), 'Man, that\'s a sweet ass-car')
+// Double Backslash should skip over it
+t.equal(xkcd37('Man, that\'s a sweet\\-ass car'), 'Man, that\'s a sweet-ass car')
+// Single Backslash won't escape and should return as if it were normal
+t.equal(xkcd37('Man, that\'s a sweet\-ass car'), 'Man, that\'s a sweet ass-car')
+// Combined use
+t.equal(xkcd37('Man, that\'s a sweet-ass car, but I think you\'re just a rich\\-ass fuck.'), 'Man, that\'s a sweet ass-car, but I think you\'re just a rich-ass fuck.')
 
 t.throws(function () {
   xkcd37(1337)


### PR DESCRIPTION
Allows not using the filter on a string passed.
Use a double backslash to not parse that part of the string.

``` js
var xkcd37 = require('xkcd-37')

xkcd37('Man, that\'s a sweet\\-ass car')
//=> 'Man, that\'s a sweet-ass car'
```
